### PR TITLE
Lisätty Muikku-verkko-oppimisympäristö ja Pyramus-oppilastietojärjestelmä

### DIFF
--- a/eduprojects.json
+++ b/eduprojects.json
@@ -1,6 +1,22 @@
 {
     "eduprojects": [       
 	{
+            "project": "Muikku verkko-oppimisympäristö",
+            "owner": "Otavan Opisto",
+            "code_url": "https://github.com/otavanopisto/muikku",
+            "service_url": "https://otavanopisto.muikkuverkko.fi/",
+            "homepage_url": "https://otavanopisto.muikkuverkko.fi/",
+	    "description": "Verkko-oppimisympäristö"	    
+	},
+	{
+            "project": "Pyramus oppilastietohallintajärjestelmä",
+            "owner": "Otavan Opisto",
+            "code_url": "https://github.com/otavanopisto/pyramus",
+            "service_url": "http://demo.pyramus.fi/",
+            "homepage_url": "http://www.pyramus.fi/",
+	    "description": "Oppilastietohallintajärjestelmä"	    
+	},
+	{
             "project": "Moodle verkko-oppimisympäristö",
             "owner": "Moodle Community",
             "code_url": "https://docs.moodle.org/dev/Main_Page",


### PR DESCRIPTION
Kyseessä on Otavan Opiston etenkin puhtaan verkko-opetuksen tarpeisiin kehittämä opetusalan ohjelmistojen parivaljakko. Muikku on usean tuhannen opiskelijan päivittäisessä käytössä, ja Pyramusta käytetään kyseisten opiskelijoiden hallinnointiin ja mm. todistusten tulostamiseen. Muikun oppimateriaaleja saavat hyödyntää kaikki ilman kirjautumista, ja kuka tahansa voi ilmoittautua aineopiskelijaksi lomakkeen (https://muikku.otavanopisto.fi/fi/aineopiskelijat_hakulomake/1_etusivu?t=1) avulla. Molemmat järjestelmät toimivat ilman ulkopuolisia kolmannen osapuolen palveluita, joskin niiden asentaminen on haastavaa.