### PR TITLE
Virastouudistus ja liikenteenohjauksen yhtiöittäminen

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -110,25 +110,25 @@
         },
         {
             "project": "Tieverkoston aineistopalvelu Digiroad",
-            "owner": "Liikennevirasto",
+            "owner": "Väylävirasto",
             "code_url": "https://github.com/finnishtransportagency/digiroad2",
-            "service_url": "-",
+            "service_url": "http://digiroad.fi",
             "homepage_url": "-",
             "demo_url": "-",
             "description": "-"
         },
         {
             "project": "Liikennetietopalvelu Digitraffic",
-            "owner": "Liikennevirasto",
-            "code_url": "https://github.com/finnishtransportagency/digitraffic",
-            "service_url": "-",
-            "homepage_url": "-",
+            "owner": "Traffic Management Finland Group",
+            "code_url": "https://github.com/tmfg/digitraffic",
+            "service_url": "https://www.digitraffic.fi",
+            "homepage_url": "https://www.digitraffic.fi",
             "demo_url": "-",
-            "description": "-"
+            "description": "Digitraffic on Traffic Management Finlandin (TMF) palvelu, jonka kautta on saatavissa ajantasaista liikennetietoa Suomen tieverkolta, rautatieliikenteestä ja meriliikenteestä. Liikennetiedot ovat avointa dataa, jota jaetaan avointen rajapintojen kautta."
         },
         {
             "project": "Joukkoliikenteen seurantajärjestelmä Juku",
-            "owner": "Liikennevirasto",
+            "owner": "Väylävirasto",
             "code_url": "https://github.com/solita/livijuku",
             "service_url": "https://juku.liikennevirasto.fi/",
             "homepage_url": "-",
@@ -182,9 +182,9 @@
         },
         {
             "project": "Digitransit, Uuden ajan matkaopas",
-            "owner": "HSL & Liikennevirasto",
+            "owner": "HSL & Väylävirasto",
             "code_url": "https://github.com/HSLdevcom/digitransit",	    
-            "service_url": "http://beta.digitransit.fi/",
+            "service_url": "http://digitransit.fi/",
             "homepage_url": "http://digitransit.fi/",
             "demo_url": "-",
             "description": "-"
@@ -218,12 +218,12 @@
         },
         {
             "project": "Harja",
-            "owner": "Liikennevirasto",
+            "owner": "Väylävirasto",
             "code_url": "https://github.com/finnishtransportagency/harja",
             "service_url": "http://finnishtransportagency.github.io/harja/",
             "homepage_url": "http://finnishtransportagency.github.io/harja/",
             "demo_url": "-",
-            "description": "Liikenneviraston väylien kunnossapidon seurannan ja raportoinnin tietojärjestelmä Harja"
+            "description": "Väyläviraston väylien kunnossapidon seurannan ja raportoinnin tietojärjestelmä Harja"
         },
         {
             "project": "Oma riista – Riistahallinnon asiointipalvelu",


### PR DESCRIPTION
Liikennevirasto muuttui Väylävirastoksi ja Digitraffic siirtyi Traffic Management Finlandille 1.1.2019