### PR TITLE
Koha-Suomi Oy: Update repository and add homepage

### DIFF
--- a/municipalityprojects.json
+++ b/municipalityprojects.json
@@ -3,9 +3,9 @@
         {
             "project": "Koha – avoimen lähdekoodin kirjastojärjestelmä",
             "owner": "Kuntien omistama Koha-Suomi Oy",
-            "code_url": "https://github.com/KohaSuomi/kohasuomi",
+            "code_url": "https://github.com/KohaSuomi/Koha",
             "service_url": "-",
-            "homepage_url": "-",
+            "homepage_url": "https://koha-suomi.fi/",
             "demo_url": "",
             "description": "Koha – avoimen lähdekoodin kirjastojärjestelmä"
         },	


### PR DESCRIPTION
KohaSuomi/kohasuomi GitHub repository is no longer maintained, and the project has moved to KohaSuomi/Koha.