### PR TITLE
Update Oskari details on projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -57,10 +57,10 @@
         {
             "project": "Oskari - avoin karttarajapintojen ja -aineistojen integraatioalusta ja asiakasohjelma",
             "owner": "Maanmittauslaitos",
-            "code_url": "https://github.com/nls-oskari",
-            "service_url": "http://www.oskari.org/",
-            "homepage_url": "http://www.oskari.org/",
-            "demo_url": "-",
+            "code_url": "https://github.com/oskariorg",
+            "service_url": "https://kartta.paikkatietoikkuna.fi/",
+            "homepage_url": "https://www.oskari.org/",
+            "demo_url": "https://demo.oskari.org/",
             "description": "Avoimen kartta-aineiston katseluun ja selailuun tarkoitettu asiakasohjelma"
         },
         {


### PR DESCRIPTION
Demo url is an actual demo platform for Oskari and service url for Paikkatietoikkuna is a service based on Oskari. GitHub repository for Oskari has changed some years ago.